### PR TITLE
chore: update default JDK_VERSION to 25 across shared workflows

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -9,7 +9,7 @@ on:
       JDK_VERSION:
         required: false
         type: string
-        default: '21'
+        default: '25'
     secrets:
       CLIENT_ID:
         required: false

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -34,10 +34,10 @@ jobs:
   deliver:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up JDK ${{inputs.JDK_VERSION}}
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{inputs.JDK_VERSION}}
           distribution: 'temurin'
@@ -61,7 +61,7 @@ jobs:
             Add-Content -Path .\src\acceptance\resources\secrets.properties -Value 'encryptionKey=${{ secrets.ENCRYPTION_KEY }}'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6.1.0
 
       - name: Execute Gradle build
         run: ./gradlew clean acceptance

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       JDK_VERSION:
         required: false
         type: string
-        default: '21'
+        default: '25'
 
 permissions: write-all
 
@@ -40,4 +40,3 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up JDK ${{ inputs.JDK_VERSION }}
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{ inputs.JDK_VERSION }}
           distribution: 'temurin'
@@ -27,7 +27,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6.1.0
 
       - name: Execute Gradle build
         run: ./gradlew clean build -P"trevorism.test.event=enabled"
@@ -35,8 +35,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: JUnit Report Action
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.4.1
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
       - run: npm install
         working-directory: ./src/app
       - run: npm run test:e2e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ on:
       JDK_VERSION:
         required: false
         type: string
-        default: '21'
+        default: '25'
     secrets:
       CLIENT_ID:
         required: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
             Add-Content -Path .\src\main\resources\secrets.properties -Value 'encryptionKey=${{ secrets.ENCRYPTION_KEY }}'
             
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v6.1.0
 
       - name: Execute Gradle build
         run: ./gradlew clean appengineStage

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,10 +45,10 @@ jobs:
   deliver:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up JDK ${{inputs.JDK_VERSION}}
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{inputs.JDK_VERSION}}
           distribution: 'temurin'
@@ -58,7 +58,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Auth with google
-        uses: 'google-github-actions/auth@v2.1.11'
+        uses: 'google-github-actions/auth@v3'
         with:
           service_account: ${{ format('github-{0}@{0}.iam.gserviceaccount.com', inputs.gcp_project ) }}
           workload_identity_provider: ${{ format('projects/{0}/locations/global/workloadIdentityPools/github-{1}-pool/providers/{1}-provider', inputs.gcp_project_id, inputs.gcp_project) }}
@@ -83,7 +83,7 @@ jobs:
             Add-Content -Path .\src\main\resources\secrets.properties -Value 'encryptionKey=${{ secrets.ENCRYPTION_KEY }}'
             
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Execute Gradle build
         run: ./gradlew clean appengineStage
@@ -91,7 +91,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Deploy to App Engine'
-        uses: 'google-github-actions/deploy-appengine@v2.1.7'
+        uses: 'google-github-actions/deploy-appengine@v3.0.1'
         with:
           working_directory: "build/staged-app"
           deliverables: 'app.yaml'

--- a/.github/workflows/jstest.yml
+++ b/.github/workflows/jstest.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: 24
       - run: npm install
         working-directory: ./src/app
       - run: npm run accept

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       JDK_VERSION:
         required: false
         type: string
-        default: '21'
+        default: '25'
 
 permissions: write-all
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK ${{ inputs.JDK_VERSION}}
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{ inputs.JDK_VERSION}}
           distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
 
       - name: Bump release version
         id: bump_version
-        uses: christian-draeger/increment-semantic-version@1.0.2
+        uses: christian-draeger/increment-semantic-version@1.2.3
         with:
           current-version: ${{ env.RELEASE_VERSION }}
           version-fragment: 'bug'
@@ -45,7 +45,7 @@ jobs:
           sed -i "/version=/ s/=.*/=${{ steps.bump_version.outputs.next-version }}/" ./gradle.properties
 
       - name: Commit change
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         with:
           commit_message: 'Bump gradle.properties'
           branch: 'master'


### PR DESCRIPTION
## Summary
Updates the default `JDK_VERSION` input from `'21'` to `'25'` across all shared Gradle-based reusable workflows.

Also update github actions workflows versions